### PR TITLE
FEAT: Add feature to export orderbook data to parquet files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,179 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+
+# Project-specific
+config.py
+data/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+orjson
+pandas
+pyarrow
+sortedcontainers
+websocket-client
+zmq


### PR DESCRIPTION
OrderBookPublisher 클래스에 저장된 오더북을 parquet 파일로 저장하는 기능을 추가하였습니다.

이에 대해, 저장 경로를 추적하지 않기 위한 .gitignore와 pyarrow에 의존으로 인한 requirements.txt를 함께 추가합니다.
.gitignore는 파이썬 템플릿에 config까지 같이 넣었습니다.


- save_mode=True인 경우, 초기화 시 parquet 파일을 저장하기 위한 인스턴스 변수 생성

- Publish 이후 저장을 위한 버퍼에 데이터 삽입 

- 매 10분마다 실행경로의 data/orderbook 경로에 저장
  - 파일 이름에 시작시간과 종료시간을 '%Y%m%d%H%M'으로 표시
    - 현재는 10분 간격이지만, 추후 달라질 수 있기 때문 

- 데이터 저장은 새로운 Thread를 열고, Queue로 이벤트(저장 트리거)를 받아서 실행
  - parquet으로 스냅샷을 저장하기 위해 현재 오더북 정보를 deepcopy 해야함
  - 10분 주기의 오더북 데이터를 복사할 때, 대략 5초 소요
  - 5초간 publish를 멈출 수는 없기 때문에 Thread에서 처리

  - 데이터를 카피하는 5초 동안 수신되는 오더북은 카피하는 중인 data_buffer에 입력 불가
  - 따라서 temp_buffer를 만들고, 카피가 완료 되면 temp_buffer를 data_buffer로 이동
  - 해당 작업 간 race condition이 있을 수 있기 때문에 lock으로 thread-safe 보장

- 다음 저장 시간은 언제 프로세스가 시작되든 10분으로 떨어지게 진행
  - 예) 09시 08분 시작 -> 09시 10분 저장
  - 지속적으로 프로세스가 진행될 예정이고, 돌리는 기간에 비해 앞뒤 잘라서 시작하는게 중요하지는 않을 것이라 판단
  - 추후, 프로세스를 멈춰야하는 일이 있다고 해도 다른 프로세스의 동시 실행하여 합치기 편리
  